### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,32 +1,32 @@
 {
-	"name": "Render Video Labels to MP4",
-	"type": "app",
-	"categories": [
-		"videos",
-		"annotation transformation",
-		"export",
-		"visualization",
-		"visualization stats"
-	],
-	"description": "Creates presentation mp4 file based on labeled video",
-	"docker_image": "supervisely/visualization-stats:6.73.564",
-	"instance_version": "6.15.60",
-	"main_script": "src/main.py",
-	"modal_template": "src/modal.html",
-	"modal_template_state": {
-		"videoId": "",
-		"allFrames": true,
-		"startFrame": 0,
-		"endFrame": 0,
-		"showClassName": true,
-		"thickness": 3,
-		"opacity": 50,
-		"pointRadius": 5
-	},
-	"task_location": "workspace_tasks",
-	"isolate": true,
-	"headless": true,
-	"icon": "https://i.imgur.com/JH93zul.png",
-	"icon_background": "#FFFFFF",
-	"poster": "https://i.imgur.com/4hmKT5z.png"
+  "name": "Render Video Labels to MP4",
+  "type": "app",
+  "categories": [
+    "videos",
+    "annotation transformation",
+    "export",
+    "visualization",
+    "visualization stats"
+  ],
+  "description": "Creates presentation mp4 file based on labeled video",
+  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
+  "instance_version": "6.15.60",
+  "main_script": "src/main.py",
+  "modal_template": "src/modal.html",
+  "modal_template_state": {
+    "videoId": "",
+    "allFrames": true,
+    "startFrame": 0,
+    "endFrame": 0,
+    "showClassName": true,
+    "thickness": 3,
+    "opacity": 50,
+    "pointRadius": 5
+  },
+  "task_location": "workspace_tasks",
+  "isolate": true,
+  "headless": true,
+  "icon": "https://i.imgur.com/JH93zul.png",
+  "icon_background": "#FFFFFF",
+  "poster": "https://i.imgur.com/4hmKT5z.png"
 }

--- a/config.json
+++ b/config.json
@@ -9,8 +9,8 @@
 		"visualization stats"
 	],
 	"description": "Creates presentation mp4 file based on labeled video",
-	"docker_image": "supervisely/visualization-stats:6.73.276",
-	"instance_version": "6.12.17",
+	"docker_image": "supervisely/visualization-stats:6.73.564",
+	"instance_version": "6.15.60",
 	"main_script": "src/main.py",
 	"modal_template": "src/modal.html",
 	"modal_template_state": {

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,1 +1,1 @@
-supervisely==6.73.276
+supervisely==6.73.564


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Updates `instance_version` in app config files.
- Does not release applications.

Validation: generated ecosystem inventory report.
