### PR TITLE
Add manual docker-build-and-push workflows

### DIFF
--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -1,0 +1,26 @@
+name: Docker Image Build
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag_version:
+        description: 'Docker Image Tag (without "v")'
+        required: true
+        type: string
+      sdk_version:
+        description: "Supervisely SDK version (optional) - only needed if SDK is installed from branch"
+        required: false
+        type: string
+        default: ""
+
+jobs:
+  docker-build-and-push:
+    uses: supervisely-ecosystem/workflows/.github/workflows/build_image.yml@master
+    secrets:
+      DOCKERHUB_USERNAME: "${{ secrets.DOCKERHUB_USERNAME }}"
+      DOCKERHUB_TOKEN: "${{ secrets.DOCKERHUB_TOKEN }}"
+    with:
+      tag_version: ${{ github.event.inputs.tag_version }}
+      dockerfile_path: docker/Dockerfile
+      image_name: "render-video-labels-to-mp4" # <- optional, if not set, will be equal to repository name
+      sdk_version: ${{ github.event.inputs.sdk_version }}

--- a/.github/workflows/dev_branch_build.yml
+++ b/.github/workflows/dev_branch_build.yml
@@ -1,0 +1,43 @@
+name: Docker Build + Release Branch
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag_version:
+        description: 'Docker Image Tag (without "v")'
+        required: true
+        type: string
+      sdk_version:
+        description: "Supervisely SDK version (optional) - only needed if SDK is installed from branch"
+        required: false
+        type: string
+        default: ""
+
+jobs:
+  docker-build-and-push:
+    uses: supervisely-ecosystem/workflows/.github/workflows/build_image.yml@master
+    secrets:
+      DOCKERHUB_USERNAME: "${{ secrets.DOCKERHUB_USERNAME }}"
+      DOCKERHUB_TOKEN: "${{ secrets.DOCKERHUB_TOKEN }}"
+    with:
+      tag_version: ${{ github.event.inputs.tag_version }}
+      dockerfile_path: docker/Dockerfile
+      image_name: "render-video-labels-to-mp4"
+      sdk_version: ${{ github.event.inputs.sdk_version }}
+
+  release-branch:
+    needs: docker-build-and-push
+    uses: supervisely-ecosystem/workflows/.github/workflows/common.yml@master
+    secrets:
+      SUPERVISELY_DEV_API_TOKEN: "${{ secrets.SUPERVISELY_DEV_API_TOKEN }}"
+      SUPERVISELY_PRIVATE_DEV_API_TOKEN: "${{ secrets.SUPERVISELY_PRIVATE_DEV_API_TOKEN }}"
+      SUPERVISELY_PROD_API_TOKEN: "${{ secrets.SUPERVISELY_PROD_API_TOKEN }}"
+      GH_ACCESS_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+    with:
+      SUPERVISELY_SERVER_ADDRESS: "${{ vars.SUPERVISELY_DEV_SERVER_ADDRESS }}"
+      SUPERVISELY_PROD_SERVER_ADDRESS: "${{ vars.SUPERVISELY_PROD_SERVER_ADDRESS }}"
+      SLUG: "${{ github.repository }}"
+      RELEASE_VERSION: "${{ github.ref_name }}"
+      RELEASE_DESCRIPTION: "'${{ github.ref_name }}' branch release"
+      RELEASE_TYPE: "release-branch"
+      SUBAPP_PATHS: "__ROOT_APP__"


### PR DESCRIPTION
Adds `build_image.yml` / `dev_branch_build.yml` (`workflow_dispatch`), mirroring the pattern already used by `yolov8`, `unet`, and `ritm-training` for building and publishing a custom docker image to `docker.io/supervisely/render-video-labels-to-mp4`.

No behavior change - these are inert until manually dispatched. Landing this on `master` first because GitHub requires a `workflow_dispatch` workflow to exist on the default branch before it becomes runnable at all (even though, once it's there, you can still pick any branch as the ref to actually build from).

This unblocks building the custom image needed by the real fix in #`case/video-export-frames-to-timecodes-crash` (a separate PR), which depends on `supervisely[video-av]` - not present in any standard Supervisely docker image.

## Test plan
- [ ] Merge this PR
- [ ] Manually dispatch `build_image.yml` selecting `case/video-export-frames-to-timecodes-crash` as the ref, with `tag_version: 6.74.10`
- [ ] Confirm the resulting image `supervisely/render-video-labels-to-mp4:6.74.10` is pullable